### PR TITLE
Created SkillTags and SkillLists

### DIFF
--- a/src/components/SkillList.tsx
+++ b/src/components/SkillList.tsx
@@ -1,0 +1,13 @@
+import SkillTag from "./SkillTag";
+
+const SkillList = ({ skills }: { skills: string[] }) => {
+  return (
+    <ul className="mt-2 flex flex-wrap" aria-label="Technologies Used">
+      {skills.map((skill) => (
+        <SkillTag key={skill} skill={skill} />
+      ))}
+    </ul>
+  );
+};
+
+export default SkillList;

--- a/src/components/SkillTag.tsx
+++ b/src/components/SkillTag.tsx
@@ -1,0 +1,9 @@
+const SkillTag = ({ skill }: { skill: string }) => {
+  return (
+    <li className="mr-1.5 mt-2 flex items-center rounded-full bg-teal-400/10 px-3 py-1 text-xs font-medium leading-5 text-teal-300">
+      {skill}
+    </li>
+  );
+};
+
+export default SkillTag;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/42fee6d2-048a-42cf-b4ad-3276590a6991)

Created `SkillTag.tsx` component:
- takes in a `skill: string` prop as a list item

Created `SkillList.tsx` component:
- component to be called in content
- takes in a `skills: string[]` prop to create unordered list of SkillTag components by mapping through skills array